### PR TITLE
BAU-3125 : Fix security issue Grunt-karma vulnerable to prototype pollution on angularjs-dropdown-multiselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "devDependencies": {
     "express": "~3.4.4",
-    "grunt": "^0.4.5",
-    "grunt-build-control": "^0.1.3",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-cssmin": "~0.7.0",
-    "grunt-contrib-jshint": "~0.7.0",
-    "grunt-contrib-less": "~0.8.1",
-    "grunt-contrib-uglify": "~0.2.5",
-    "grunt-karma": "~0.6.2"
+    "grunt": "^1.6.1",
+    "grunt-build-control": "^0.7.1",
+    "grunt-contrib-concat": "^2.1.0",
+    "grunt-contrib-cssmin": "^5.0.0",
+    "grunt-contrib-jshint": "^3.2.0",
+    "grunt-contrib-less": "^3.0.0",
+    "grunt-contrib-uglify": "^5.2.2",
+    "grunt-karma": "^4.0.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "repository": "git@github.com:ubreakifix/angularjs-dropdown-multiselect.git",
   "engines": {
-    "node": "0.10.10"
+    "node": "14.21.3"
   }
 }


### PR DESCRIPTION
**Technical Details**

Type: Grunt-karma vulnerable to prototype pollution
Target: angularjs-dropdown-multiselect
First Found: 10/19/23 18:01
Last Found: 10/19/23 18:01
Platform: UBIF-BIFFY
Link: https://github.com/ubreakifix/angularjs-dropdown-multiselect/security/dependabot/6

**Vulnerability Details**
Prototype pollution vulnerability in karma-runner grunt-karma 4.0.1 via the `key` variable in `grunt-karma.js`.

**Remediation Timeline**
Due Date: 11/18/23 18:01
Created: 3/11/25 20:35

**Screen where I have tested multi select**

Screen Path : https://dev-dhamecha-bau.ubif-nonprod.net/corporate/stores/edit/430 (Corporate->Store-Edit)
<img width="1580" height="707" alt="image" src="https://github.com/user-attachments/assets/f046eac2-a5d9-4571-aa23-5941916f76b8" />

SCreen Path : https://dev-dhamecha-bau.ubif-nonprod.net/pos (POS)
<img width="1582" height="710" alt="image" src="https://github.com/user-attachments/assets/d09423e7-0a60-4c84-8142-b1c7a1141029" />

**Local Dev box multi select node_module**
<img width="1590" height="750" alt="image" src="https://github.com/user-attachments/assets/a37c707e-9261-4351-a5c0-20cb130b82b6" />

@s-calderon @bakihanma20 @asurionsudarshanphule I have checked this component in biffy, I am not sure in other app we are using this component or not. Please let me know if any other app we have to check this component. I have provided some SS regarding the package version change and screen of my DEV BOX for your reference.



